### PR TITLE
More platinum overhaul stuff

### DIFF
--- a/src/main/java/gregicadditions/GAMaterials.java
+++ b/src/main/java/gregicadditions/GAMaterials.java
@@ -5,6 +5,7 @@ import gregicadditions.item.BasicMaterial;
 import gregtech.api.unification.Element;
 import gregtech.api.unification.material.IMaterialHandler;
 import gregtech.api.unification.material.MaterialIconSet;
+import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.*;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
@@ -188,9 +189,9 @@ public class GAMaterials implements IMaterialHandler {
     public static final FluidMaterial Diphenylisophtalate = new FluidMaterial(841, "diphenylisophtalate", 0x246E57, MaterialIconSet.DULL, of(), 0);
     public static final DustMaterial Polybenzimidazole = new DustMaterial(840, "polybenzimidazole", 0x2D2D2D, MaterialIconSet.DULL, 0, of(), 0);
 
-
     @Override
     public void onMaterialsInit() {
+
         Enderium.setFluidPipeProperties(650, 1500, true);
         Neutronium.setFluidPipeProperties(2800, 1000000, true);
         Naquadah.setFluidPipeProperties(1000, 19000, true);

--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -164,7 +164,7 @@ public class GregicAdditions {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void registerRecipes2(RegistryEvent.Register<IRecipe> event) {
-
+        GARecipeAddition.replaceOre();
     }
 
     private <T extends Block> ItemBlock createItemBlock(T block, Function<T, ItemBlock> producer) {

--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -158,11 +158,13 @@ public class GregicAdditions {
         RecipeHandler.registerAlloyBlastRecipes();
         RecipeHandler.registerChemicalPlantRecipes();
         VoidMinerOres.init();
+        GARecipeAddition.hjaeOreProcessing();
+
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void registerRecipes2(RegistryEvent.Register<IRecipe> event) {
-        GARecipeAddition.hjaeOreProcessing();
+
     }
 
     private <T extends Block> ItemBlock createItemBlock(T block, Function<T, ItemBlock> producer) {

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -1638,7 +1638,8 @@ public class GARecipeAddition {
         Recipe recipe = null;
         for (MaterialStack materialComponent : material.materialComponents) {
             if (platinumGroupMaterials.contains(materialComponent.material)) {
-                findElectrolyzerRecipe(map, material, orePrefix);
+                //findElectrolyzerRecipe(map, material, orePrefix);
+                //pointless wont work
             }
         }
         if (map == CHEMICAL_BATH_RECIPES && material instanceof DustMaterial && ((DustMaterial) material).washedIn != null) {

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -1634,35 +1634,7 @@ public class GARecipeAddition {
         GTLog.logger.info("Time taken: " + (System.currentTimeMillis() - t1));
     }
 
-    static <R extends RecipeBuilder<R>> void findRecipe(RecipeMap<R> map, Material material, OrePrefix orePrefix) {
-        Recipe recipe = null;
-        for (MaterialStack materialComponent : material.materialComponents) {
-            if (platinumGroupMaterials.contains(materialComponent.material)) {
-                //findElectrolyzerRecipe(map, material, orePrefix);
-                //pointless wont work
-            }
-        }
-        if (map == CHEMICAL_BATH_RECIPES && material instanceof DustMaterial && ((DustMaterial) material).washedIn != null) {
-            List<FluidStack> fluidInputs = new ArrayList<>();
-            fluidInputs.add(((DustMaterial) material).washedIn.getFluid(1000));
-            recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), fluidInputs, Integer.MAX_VALUE);
-        } else if (map == ORE_WASHER_RECIPES) {
-            List<FluidStack> water = new ArrayList<>();
-            List<FluidStack> distilledWater = new ArrayList<>();
-            water.add(Water.getFluid(1000));
-            distilledWater.add(DistilledWater.getFluid(1000));
-            recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), water, Integer.MAX_VALUE);
-            Recipe distilledWaterRecipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), distilledWater, Integer.MAX_VALUE);
-                if(distilledWaterRecipe != null) {
-                    buildNewOutputs(map, distilledWaterRecipe);
-                }
-        } else {
-            recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), Collections.emptyList(), Integer.MAX_VALUE);
-        }
-        if (recipe != null) {
-            buildNewOutputs(map, recipe);
-        }
-    }
+
 
     static <R extends RecipeBuilder<R>> void findElectrolyzerRecipe(RecipeMap<R> map, Material material, OrePrefix orePrefix) {
         int totalComponents = 0;
@@ -1717,6 +1689,35 @@ public class GARecipeAddition {
     }
 
 
+    static void findRecipe(RecipeMap<?> map, Material material, OrePrefix orePrefix) {
+        Recipe recipe = null;
+        for (MaterialStack materialComponent : material.materialComponents) {
+            if (platinumGroupMaterials.contains(materialComponent.material)) {
+                //findElectrolyzerRecipe(map, material, orePrefix);
+                //pointless wont work
+            }
+        }
+        if (map == CHEMICAL_BATH_RECIPES && material instanceof DustMaterial && ((DustMaterial) material).washedIn != null) {
+            List<FluidStack> fluidInputs = new ArrayList<>();
+            fluidInputs.add(((DustMaterial) material).washedIn.getFluid(1000));
+            recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), fluidInputs, Integer.MAX_VALUE);
+        } else if (map == ORE_WASHER_RECIPES) {
+            List<FluidStack> water = new ArrayList<>();
+            List<FluidStack> distilledWater = new ArrayList<>();
+            water.add(Water.getFluid(1000));
+            distilledWater.add(DistilledWater.getFluid(1000));
+            recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), water, Integer.MAX_VALUE);
+            Recipe distilledWaterRecipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), distilledWater, Integer.MAX_VALUE);
+            if(distilledWaterRecipe != null) {
+                buildNewOutputs(map, distilledWaterRecipe);
+            }
+        } else {
+            recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(OreDictUnifier.get(orePrefix, material)), Collections.emptyList(), Integer.MAX_VALUE);
+        }
+        if (recipe != null) {
+            buildNewOutputs(map, recipe);
+        }
+    }
 
 
     public static void forestrySupport() {

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -1273,13 +1273,6 @@ public class GARecipeAddition {
 
         //Platinum Process
 
-        MACERATOR_RECIPES.recipeBuilder()
-                .input(ore, Iridium)
-                .outputs(OreDictUnifier.get(dust, IrLeachResidue))
-                .duration(400)
-                .EUt(2)
-                .buildAndRegister();
-
         BLAST_RECIPES.recipeBuilder()
                 .blastFurnaceTemp(775)
                 .input(dust, IrLeachResidue)


### PR DESCRIPTION
Fix chemical bath, ore washer. Handle chanced outputs. Moved oreprocessing to low priority instead of lowest to stop interference with CT scripts. Disabled modification of electrolyzer recipes because that has to be done in lowest priority.